### PR TITLE
Open links in default browser

### DIFF
--- a/Sources/Application.swift
+++ b/Sources/Application.swift
@@ -267,6 +267,7 @@ class Application {
                 self.channelsListView.draw(self.context, selectionId: suggestion.id, unreadIds: self.unreadChannelsIds)
             
                 self.reloadChannel(suggestion.id)
+                self.context.links.removeAll()
                 self.userInputView.draw()
                 
             case .other(let character):

--- a/Sources/Application.swift
+++ b/Sources/Application.swift
@@ -5,7 +5,6 @@
 //
 
 import Foundation
-import AppKit
 
 class Application {
     
@@ -301,7 +300,7 @@ class Application {
             let linkNumbers = pieces.flatMap { Int($0) }
             for linkNumber in linkNumbers {
                 let url = self.links[linkNumber - 1]
-                NSWorkspace.shared().open(NSURL(string: url)! as URL)
+                Utils.shell("open", url)
             }
             return true
         }

--- a/Sources/Application.swift
+++ b/Sources/Application.swift
@@ -142,7 +142,7 @@ class Application {
     }
     
     private func messageListRowFor(message: SlackMessage) -> MessagesListRow {
-        let spans = self.adapter.textSpansFor(message: message, withContext: self.context)
+        let spans = self.adapter.textSpansFor(message: message, withContext: self.context, andLinks: &self.context.links)
         return MessagesListRow(channel: message.channel, id: message.ts, spans: spans)
     }
     

--- a/Sources/Application.swift
+++ b/Sources/Application.swift
@@ -18,6 +18,7 @@ class Application {
     private let rtmClient                       : SlackRealTimeClient
     
     private var messages                        = Array<MessagesListRow>()
+    private var links                           = [String]()
     private var selectedChannel: String?        = nil
     private var replyIdCounter                  = 0
     private var unreadChannelsIds               = Set<String>()
@@ -143,7 +144,7 @@ class Application {
     }
     
     private func messageListRowFor(message: SlackMessage) -> MessagesListRow {
-        let spans = self.adapter.textSpansFor(message: message, withContext: self.context, andLinks: &self.context.links)
+        let spans = self.adapter.textSpansFor(message: message, withContext: self.context, andLinks: &self.links)
         return MessagesListRow(channel: message.channel, id: message.ts, spans: spans)
     }
     
@@ -270,7 +271,7 @@ class Application {
                 self.channelsListView.draw(self.context, selectionId: suggestion.id, unreadIds: self.unreadChannelsIds)
             
                 self.reloadChannel(suggestion.id)
-                self.context.links.removeAll()
+                self.links.removeAll()
                 self.userInputView.draw()
                 
             case .other(let character):
@@ -299,7 +300,7 @@ class Application {
             let pieces = command.components(separatedBy: [",", " "])
             let linkNumbers = pieces.flatMap { Int($0) }
             for linkNumber in linkNumbers {
-                let url = self.context.links[linkNumber - 1]
+                let url = self.links[linkNumber - 1]
                 NSWorkspace.shared().open(NSURL(string: url)! as URL)
             }
             return true

--- a/Sources/SlackAdapter.swift
+++ b/Sources/SlackAdapter.swift
@@ -26,7 +26,7 @@ class SlackAdapter {
         }
     }
     
-    func textSpansFor(message: SlackMessage, withContext context: SlackContext) -> [TextSpan] {
+    func textSpansFor(message: SlackMessage, withContext context: SlackContext, andLinks links: inout [String]) -> [TextSpan] {
         
         let slackUser = context.user(forId: message.user) ?? SlackUser(id: "", name: "unknonw", color: "", presence: .away)
         
@@ -35,13 +35,13 @@ class SlackAdapter {
         spans.append(TextSpan(self.formatSlackTimestamp(message.ts), withColor: R.color.messageTimeTextColor))
         spans.append(TextSpan(" \(slackUser.name)", withColor: Utils.xterm256Color(forUser: slackUser)))
         spans.append(TextSpan(": ", withColor: R.color.messagePrefixTextColor))
-        spans.append(contentsOf: self.spansFor(message: message.text, withContext: context))
+        spans.append(contentsOf: self.spansFor(message: message.text, withContext: context, andLinks: &links))
         
         return spans
     }
     
     
-    func spansFor(message: String, withContext context: SlackContext) -> [TextSpan] {
+    func spansFor(message: String, withContext context: SlackContext, andLinks links: inout [String]) -> [TextSpan] {
         
         var spans = [TextSpan]()
         
@@ -77,6 +77,7 @@ class SlackAdapter {
                         }
                     } else {
                         spans.append(TextSpan(self.escapeHTMLEntities(String(message.characters[escapeStartIndex..<escapeEndIndex])), withColor: R.color.linkTextColor))
+                        context.links.append(String(message.characters[escapeStartIndex..<escapeEndIndex]))
                     }
                 }
                 spanStart = message.characters.index(escapeEndIndex, offsetBy: 1)

--- a/Sources/SlackAdapter.swift
+++ b/Sources/SlackAdapter.swift
@@ -77,8 +77,8 @@ class SlackAdapter {
                         }
                     } else {
                         spans.append(TextSpan(self.escapeHTMLEntities(String(message.characters[escapeStartIndex..<escapeEndIndex])), withColor: R.color.linkTextColor))
-                        context.links.append(String(message.characters[escapeStartIndex..<escapeEndIndex]))
-                        spans.append(TextSpan("[" + String(context.links.count) + "]", withColor: R.color.messageTextColor))
+                        links.append(String(message.characters[escapeStartIndex..<escapeEndIndex]))
+                        spans.append(TextSpan("[" + String(links.count) + "]", withColor: R.color.messageTextColor))
                     }
                 }
                 spanStart = message.characters.index(escapeEndIndex, offsetBy: 1)

--- a/Sources/SlackAdapter.swift
+++ b/Sources/SlackAdapter.swift
@@ -78,6 +78,7 @@ class SlackAdapter {
                     } else {
                         spans.append(TextSpan(self.escapeHTMLEntities(String(message.characters[escapeStartIndex..<escapeEndIndex])), withColor: R.color.linkTextColor))
                         context.links.append(String(message.characters[escapeStartIndex..<escapeEndIndex]))
+                        spans.append(TextSpan("[" + String(context.links.count) + "]", withColor: R.color.messageTextColor))
                     }
                 }
                 spanStart = message.characters.index(escapeEndIndex, offsetBy: 1)

--- a/Sources/SlackContext.swift
+++ b/Sources/SlackContext.swift
@@ -16,7 +16,6 @@ class SlackContext {
     var channels = [SlackChannel]()
     var groups   = [SlackGroup]()
     var ims      = [SlackIM]()
-    var links    = [String]()
     
     init(withTeam team: SlackTeam) {
         self.teamName = team.name

--- a/Sources/SlackContext.swift
+++ b/Sources/SlackContext.swift
@@ -16,6 +16,7 @@ class SlackContext {
     var channels = [SlackChannel]()
     var groups   = [SlackGroup]()
     var ims      = [SlackIM]()
+    var links    = [String]()
     
     init(withTeam team: SlackTeam) {
         self.teamName = team.name


### PR DESCRIPTION
Implement /openurl to open links in a browser

Introduce the concept of local commands. The first one supported is `/openurl` which takes a list of link numbers which are displayed next to each link in the message view. Executing `/openurl` opens each link in the default browser.

Looks as shown here:
<img width="925" alt="openlinks" src="https://cloud.githubusercontent.com/assets/33135/21459511/b30b6850-c936-11e6-9da5-981fb468afaa.png">