### PR TITLE
Replace use of NSURLConnection.sendSynchronousRequest

### DIFF
--- a/Sources/SlackOAuth2.swift
+++ b/Sources/SlackOAuth2.swift
@@ -58,8 +58,12 @@ class SlackOAuth2 {
                 
                 do {
                     
-                    let object = try JSONSerialization.jsonObject(with:
-                        try NSURLConnection.sendSynchronousRequest(URLRequest(url: url), returning: nil))
+                    let (theData, _) = try URLSession.shared.synchronousDataTask(with: URLRequest(url: url))
+                    guard let data = theData else {
+                        responder(TextResponse(200, "No response from Slack."))
+                        return
+                    }
+                    let object = try JSONSerialization.jsonObject(with:data)
                     
                     guard let dict = object as? Dictionary<String, Any> else {
                         responder(TextResponse(200, "Slack's response is not a dictionary \(object)."))

--- a/Sources/SlackWebClient.swift
+++ b/Sources/SlackWebClient.swift
@@ -67,8 +67,11 @@ class SlackWebClient {
             throw SlackWebClientError.error("Could not create URL object.")
         }
         
-        let object = try JSONSerialization.jsonObject(with:
-            try NSURLConnection.sendSynchronousRequest(URLRequest(url: url), returning: nil))
+        let (theData, _) = try URLSession.shared.synchronousDataTask(with: URLRequest(url: url))
+        guard let data = theData else {
+            throw SlackWebClientError.error("Error receiving data.")
+        }
+        let object = try JSONSerialization.jsonObject(with:data)
         
         guard let dict = object as? Dictionary<String, Any> else {
             throw SlackWebClientError.error("\(rpcMethod)'s response is not a dictionary.")

--- a/Sources/URLSession.swift
+++ b/Sources/URLSession.swift
@@ -1,0 +1,41 @@
+//
+//  slash
+//
+//  Copyright © 2016 slash Corp. All rights reserved.
+//
+
+import Foundation
+
+extension URLSession {
+
+    /// Synchonized version of dataTask(with URLRequest)
+    func synchronousDataTask(with request: URLRequest) throws -> (data: Data?, response: HTTPURLResponse?) {
+        
+        let semaphore = DispatchSemaphore(value: 0)
+        
+        var data: Data?
+        var response: URLResponse?
+        var error: Error?
+        
+        URLSession.shared.dataTask(with: request) { (theData, theResponse, theError) -> Void in
+            // extract information from callback
+            data = theData
+            response = theResponse
+            error = theError
+            
+            // wake semaphore
+            semaphore.signal()
+            
+            }.resume()
+        
+        // wait until signaled
+        _ = semaphore.wait(timeout: .distantFuture)
+        
+        // do we have an error?
+        if let error = error {
+            throw error
+        }
+        
+        return (data: data, response: response as! HTTPURLResponse?)
+    }
+}

--- a/slash.xcodeproj/project.pbxproj
+++ b/slash.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		7C92EB871E03F3FC00F92267 /* SlackWebClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C92EB7A1E03F3FC00F92267 /* SlackWebClient.swift */; };
 		7C92EB881E03F3FC00F92267 /* TLSSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C92EB7B1E03F3FC00F92267 /* TLSSocket.swift */; };
 		7C92EB891E03F3FC00F92267 /* WebSocketClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C92EB7C1E03F3FC00F92267 /* WebSocketClient.swift */; };
+		D42C5DF71E156BEE008CDA3C /* URLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D42C5DF61E156BEE008CDA3C /* URLSession.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -77,6 +78,7 @@
 		7C92EB7B1E03F3FC00F92267 /* TLSSocket.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TLSSocket.swift; path = Sources/TLSSocket.swift; sourceTree = SOURCE_ROOT; };
 		7C92EB7C1E03F3FC00F92267 /* WebSocketClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WebSocketClient.swift; path = Sources/WebSocketClient.swift; sourceTree = SOURCE_ROOT; };
 		7CBB81F21DC12E8B00DC0334 /* slash */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = slash; sourceTree = BUILT_PRODUCTS_DIR; };
+		D42C5DF61E156BEE008CDA3C /* URLSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = URLSession.swift; path = Sources/URLSession.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -93,6 +95,7 @@
 		7C4A722A1DE5CC91005A72EF /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				D42C5DF51E156A2A008CDA3C /* Extensions */,
 				7C4A725F1DE5CCD4005A72EF /* App */,
 				7C4A725E1DE5CCB6005A72EF /* Slack */,
 				7C4A725D1DE5CCA3005A72EF /* Terminal */,
@@ -163,6 +166,14 @@
 				7CBB81F21DC12E8B00DC0334 /* slash */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		D42C5DF51E156A2A008CDA3C /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				D42C5DF61E156BEE008CDA3C /* URLSession.swift */,
+			);
+			name = Extensions;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -245,6 +256,7 @@
 				7C92EB651E03F3ED00F92267 /* Application.swift in Sources */,
 				7C92EB831E03F3FC00F92267 /* SlackOAuth2.swift in Sources */,
 				7C92EB6D1E03F3ED00F92267 /* SlackContext.swift in Sources */,
+				D42C5DF71E156BEE008CDA3C /* URLSession.swift in Sources */,
 				7C92EB841E03F3FC00F92267 /* SlackRealTimeClient.swift in Sources */,
 				7C92EB851E03F3FC00F92267 /* SlackTeam.swift in Sources */,
 				7C92EB581E03F3C900F92267 /* TerminalDevice.swift in Sources */,


### PR DESCRIPTION
This method is deprecated in favour of using URLSession's dataTask methods. However, dataTask is asynchronous, so we extend URLSession to create a new synchronousDataTask method which wraps up the asynchronicity for us.