### PR TITLE
Only display subscribed channels

### DIFF
--- a/Sources/ChannelsListView.swift
+++ b/Sources/ChannelsListView.swift
@@ -66,6 +66,9 @@ class ChannelsListView {
         self.canvas.color(R.color.channelNameTextColor);
         
         for channel in context.channels {
+            if (!channel.isMember) {
+                continue
+            }
         
             self.drawRow("#" + channel.name, row: offset, highlight: channel.id == selectionId, blink: unreadIds.contains(channel.id))
             

--- a/Sources/SlackChannel.swift
+++ b/Sources/SlackChannel.swift
@@ -13,4 +13,5 @@ struct SlackChannel {
     let members: [String]
     let topic: String
     let general: Bool
+    let isMember: Bool
 }

--- a/Sources/SlackWebClient.swift
+++ b/Sources/SlackWebClient.swift
@@ -92,10 +92,15 @@ class SlackWebClient {
             users: (object ←← "users").map(
                 { SlackUser(id: $0 ← "id", name: $0 ← "name", color: $0 ← "color", presence: ($0 ← "presence") == "active" ? .active : .away) }
             ),
-            channels: (object ←← "channels").map(
-                { SlackChannel(id: $0 ← "id", name: $0 ← "name",
+            channels: (object ←← "channels").map({
+                SlackChannel(
+                    id: $0 ← "id",
+                    name: $0 ← "name",
                     members: ($0 ←← "members").map({ ($0 as? String) ?? "" }),
-                    topic: $0 ← "topic", general: $0 ← "is_general") }
+                    topic: $0 ← "topic",
+                    general: $0 ← "is_general",
+                    isMember: $0 ← "is_member"
+                )}
             ),
             groups: (object ←← "groups").map(
                 { SlackGroup(id: $0 ← "id", name: $0 ← "name",


### PR DESCRIPTION
We can't post messages to channels that we are not members of, so we shouldn't display them in the list.

Presumably, at some point, we'll have a means to join and leave channels…