### PR TITLE
Send macOS desktop notifications

### DIFF
--- a/Sources/Application.swift
+++ b/Sources/Application.swift
@@ -128,8 +128,13 @@ class Application {
             
         case .desktopNotification(let title, let message):
 
-            return self.appendRow(MessagesListRow(spans: ["NOTIFICATION", " : ", TextSpan(title)]))
-            
+            #if os(Linux)
+                // Linux notifications not implemented yet
+            #else
+                Process.launchedProcess(launchPath: "/usr/bin/osascript", arguments: ["-e", "display notification \"\(message)\" with title \"slash: \(title)\""])
+            #endif
+            return
+
         case .unknown(let message):
             
             return self.appendRow(MessagesListRow(spans: ["?", " : ", TextSpan(message)]))

--- a/Sources/Application.swift
+++ b/Sources/Application.swift
@@ -126,6 +126,10 @@ class Application {
             
             self.channelsListView.draw(self.context, selectionId: self.selectedChannel, unreadIds: self.unreadChannelsIds)
             
+        case .desktopNotification(let title, let message):
+
+            return self.appendRow(MessagesListRow(spans: ["NOTIFICATION", " : ", TextSpan(title)]))
+            
         case .unknown(let message):
             
             return self.appendRow(MessagesListRow(spans: ["?", " : ", TextSpan(message)]))

--- a/Sources/SlackEvent.swift
+++ b/Sources/SlackEvent.swift
@@ -29,4 +29,5 @@ enum SlackEvent {
     case userChange
     case reply(Int, String)
     case teamRename(String)
+    case desktopNotification(String, String)
 }

--- a/Sources/SlackRealTimeClient.swift
+++ b/Sources/SlackRealTimeClient.swift
@@ -94,7 +94,7 @@ class SlackRealTimeClient {
                     let name = (dictionary["name"] as? String) ?? ""
                     return .teamRename(name)
                 case "desktop_notification":
-                    let title = ((dictionary["title"] as? String) ?? "") + ((dictionary["subtitle"] as? String) ?? "")
+                    let title = ((dictionary["title"] as? String) ?? "") + " " + ((dictionary["subtitle"] as? String) ?? "")
                     let message = ((dictionary["content"] as? String) ?? "")
                     return .desktopNotification(title, message)
                 default:

--- a/Sources/SlackRealTimeClient.swift
+++ b/Sources/SlackRealTimeClient.swift
@@ -93,6 +93,10 @@ class SlackRealTimeClient {
                 case "team_rename":
                     let name = (dictionary["name"] as? String) ?? ""
                     return .teamRename(name)
+                case "desktop_notification":
+                    let title = ((dictionary["title"] as? String) ?? "") + ((dictionary["subtitle"] as? String) ?? "")
+                    let message = ((dictionary["content"] as? String) ?? "")
+                    return .desktopNotification(title, message)
                 default:
                     return .unknown("\(type) - \(dictionary)")
             }


### PR DESCRIPTION
As we aren't an Application Bundle, we can't use NSUserNotificationCenter
as it doesn't work according to [terminal-notifier][1] (radar://11956694). We can use AppleScript though via osascript.

This is macOS specific, so I've guarded it so that it won't break on Linux.

[1]: https://github.com/julienXX/terminal-notifier/blob/master/README.markdown